### PR TITLE
Add import annotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.2.18 / 2022-10-14
+
+* Added support for the `#import` annotation to the `loadFile` function. This was an open suggestion [here](https://github.com/tiago154/graphql-import-files/issues/16) that way we can add the reading of a file and if necessary include other files through the import annotation.
+
 ### v1.1.18 / 2022-10-01
 
 * Change the return of the `loadFile` function to `DocumentNode`, to be compatible with the subgraph architecture offered by the `@apollo/subgraph - buildSubgraphSchema` package.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Light and easy package that will load .graphql files and use them with syntax hi
 npm i -S graphql-import-files
 ```
 
-## Usage
+## Usage:
 
-### Loading a single file
+## Loading a single file
 
 For example, your files and folders look like this:
 
@@ -54,7 +54,60 @@ server.listen().then(({ url }) => {
 })
 ```
 
-### Loading multiple files
+**The `loadFile` function supports the `#import` annotation and this will allow you to load other files as if it were the import in a js file.**
+
+```
+root
+├──src
+  ├──index.js
+  ├──schema
+    ├──schema.graphql
+    ├──user
+      ├──user.graphql
+    ├──location
+      ├──location.graphql
+```
+
+./src/schema/schema.graphql
+```graphql
+#import './user/user.graphql'
+#import './location/location.graphql'
+
+type Query {
+  user(id: ID!): User
+  location(id: ID!): Location
+}
+```
+
+./src/schema/user/user.graphql
+```graphql
+type User {
+  id: ID!
+  name: String!
+}
+```
+
+./src/schema/location/location.graphql
+```graphql
+type Location {
+  id: ID!
+  name: String!
+}
+```
+
+```js
+// index.js
+// ...
+const { loadFile } = require('graphql-import-files')
+
+const server = new ApolloServer({
+  typeDefs: loadFile('./schema/schema.graphql'), // Always consider the path at the root of the project
+  resolvers
+})
+// ...
+```
+
+## Loading multiple files
 
 For example, your files and folders look like this:
 

--- a/__tests__/__snapshots__/loadFile.test.ts.snap
+++ b/__tests__/__snapshots__/loadFile.test.ts.snap
@@ -1,6 +1,778 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loadFile success should valid schema 1`] = `
+exports[`loadFile when file path is valid and has file import annotation should valid schema 1`] = `
+{
+  "definitions": [
+    {
+      "description": undefined,
+      "directives": [],
+      "fields": [
+        {
+          "arguments": [
+            {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": [],
+              "kind": "InputValueDefinition",
+              "loc": {
+                "end": 152,
+                "start": 145,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 147,
+                  "start": 145,
+                },
+                "value": "id",
+              },
+              "type": {
+                "kind": "NonNullType",
+                "loc": {
+                  "end": 152,
+                  "start": 149,
+                },
+                "type": {
+                  "kind": "NamedType",
+                  "loc": {
+                    "end": 151,
+                    "start": 149,
+                  },
+                  "name": {
+                    "kind": "Name",
+                    "loc": {
+                      "end": 151,
+                      "start": 149,
+                    },
+                    "value": "ID",
+                  },
+                },
+              },
+            },
+          ],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 160,
+            "start": 140,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 144,
+              "start": 140,
+            },
+            "value": "user",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 160,
+              "start": 155,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 159,
+                "start": 155,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 159,
+                  "start": 155,
+                },
+                "value": "User",
+              },
+            },
+          },
+        },
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 179,
+            "start": 164,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 169,
+              "start": 164,
+            },
+            "value": "users",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 179,
+              "start": 171,
+            },
+            "type": {
+              "kind": "ListType",
+              "loc": {
+                "end": 178,
+                "start": 171,
+              },
+              "type": {
+                "kind": "NonNullType",
+                "loc": {
+                  "end": 177,
+                  "start": 172,
+                },
+                "type": {
+                  "kind": "NamedType",
+                  "loc": {
+                    "end": 176,
+                    "start": 172,
+                  },
+                  "name": {
+                    "kind": "Name",
+                    "loc": {
+                      "end": 176,
+                      "start": 172,
+                    },
+                    "value": "User",
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 206,
+            "start": 183,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 192,
+              "start": 183,
+            },
+            "value": "locations",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 206,
+              "start": 194,
+            },
+            "type": {
+              "kind": "ListType",
+              "loc": {
+                "end": 205,
+                "start": 194,
+              },
+              "type": {
+                "kind": "NonNullType",
+                "loc": {
+                  "end": 204,
+                  "start": 195,
+                },
+                "type": {
+                  "kind": "NamedType",
+                  "loc": {
+                    "end": 203,
+                    "start": 195,
+                  },
+                  "name": {
+                    "kind": "Name",
+                    "loc": {
+                      "end": 203,
+                      "start": 195,
+                    },
+                    "value": "Location",
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+      "interfaces": [],
+      "kind": "ObjectTypeDefinition",
+      "loc": {
+        "end": 209,
+        "start": 124,
+      },
+      "name": {
+        "kind": "Name",
+        "loc": {
+          "end": 134,
+          "start": 129,
+        },
+        "value": "Query",
+      },
+    },
+    {
+      "description": undefined,
+      "directives": [],
+      "fields": [
+        {
+          "arguments": [
+            {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": [],
+              "kind": "InputValueDefinition",
+              "loc": {
+                "end": 273,
+                "start": 244,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 257,
+                  "start": 244,
+                },
+                "value": "locationInput",
+              },
+              "type": {
+                "kind": "NonNullType",
+                "loc": {
+                  "end": 273,
+                  "start": 259,
+                },
+                "type": {
+                  "kind": "NamedType",
+                  "loc": {
+                    "end": 272,
+                    "start": 259,
+                  },
+                  "name": {
+                    "kind": "Name",
+                    "loc": {
+                      "end": 272,
+                      "start": 259,
+                    },
+                    "value": "locationInput",
+                  },
+                },
+              },
+            },
+          ],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 285,
+            "start": 232,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 243,
+              "start": 232,
+            },
+            "value": "addLocation",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 285,
+              "start": 276,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 284,
+                "start": 276,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 284,
+                  "start": 276,
+                },
+                "value": "Location",
+              },
+            },
+          },
+        },
+      ],
+      "interfaces": [],
+      "kind": "ObjectTypeDefinition",
+      "loc": {
+        "end": 288,
+        "start": 213,
+      },
+      "name": {
+        "kind": "Name",
+        "loc": {
+          "end": 226,
+          "start": 218,
+        },
+        "value": "Mutation",
+      },
+    },
+    {
+      "description": undefined,
+      "directives": [],
+      "fields": [
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 22,
+            "start": 15,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 17,
+              "start": 15,
+            },
+            "value": "id",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 22,
+              "start": 19,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 21,
+                "start": 19,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 21,
+                  "start": 19,
+                },
+                "value": "ID",
+              },
+            },
+          },
+        },
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 39,
+            "start": 26,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 30,
+              "start": 26,
+            },
+            "value": "name",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 39,
+              "start": 32,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 38,
+                "start": 32,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 38,
+                  "start": 32,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+      ],
+      "interfaces": [],
+      "kind": "ObjectTypeDefinition",
+      "loc": {
+        "end": 42,
+        "start": 0,
+      },
+      "name": {
+        "kind": "Name",
+        "loc": {
+          "end": 9,
+          "start": 5,
+        },
+        "value": "User",
+      },
+    },
+    {
+      "description": undefined,
+      "directives": [],
+      "fields": [
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 26,
+            "start": 19,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 21,
+              "start": 19,
+            },
+            "value": "id",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 26,
+              "start": 23,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 25,
+                "start": 23,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 25,
+                  "start": 23,
+                },
+                "value": "ID",
+              },
+            },
+          },
+        },
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 43,
+            "start": 30,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 34,
+              "start": 30,
+            },
+            "value": "name",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 43,
+              "start": 36,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 42,
+                "start": 36,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 42,
+                  "start": 36,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 67,
+            "start": 47,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 58,
+              "start": 47,
+            },
+            "value": "description",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 67,
+              "start": 60,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 66,
+                "start": 60,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 66,
+                  "start": 60,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 85,
+            "start": 71,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 76,
+              "start": 71,
+            },
+            "value": "photo",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 85,
+              "start": 78,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 84,
+                "start": 78,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 84,
+                  "start": 78,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+      ],
+      "interfaces": [],
+      "kind": "ObjectTypeDefinition",
+      "loc": {
+        "end": 88,
+        "start": 0,
+      },
+      "name": {
+        "kind": "Name",
+        "loc": {
+          "end": 13,
+          "start": 5,
+        },
+        "value": "Location",
+      },
+    },
+    {
+      "description": undefined,
+      "directives": [],
+      "fields": [
+        {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": [],
+          "kind": "InputValueDefinition",
+          "loc": {
+            "end": 130,
+            "start": 117,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 121,
+              "start": 117,
+            },
+            "value": "name",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 130,
+              "start": 123,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 129,
+                "start": 123,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 129,
+                  "start": 123,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+        {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": [],
+          "kind": "InputValueDefinition",
+          "loc": {
+            "end": 154,
+            "start": 134,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 145,
+              "start": 134,
+            },
+            "value": "description",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 154,
+              "start": 147,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 153,
+                "start": 147,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 153,
+                  "start": 147,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+        {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": [],
+          "kind": "InputValueDefinition",
+          "loc": {
+            "end": 172,
+            "start": 158,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 163,
+              "start": 158,
+            },
+            "value": "photo",
+          },
+          "type": {
+            "kind": "NonNullType",
+            "loc": {
+              "end": 172,
+              "start": 165,
+            },
+            "type": {
+              "kind": "NamedType",
+              "loc": {
+                "end": 171,
+                "start": 165,
+              },
+              "name": {
+                "kind": "Name",
+                "loc": {
+                  "end": 171,
+                  "start": 165,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": {
+        "end": 175,
+        "start": 92,
+      },
+      "name": {
+        "kind": "Name",
+        "loc": {
+          "end": 111,
+          "start": 98,
+        },
+        "value": "locationInput",
+      },
+    },
+    {
+      "kind": "SchemaDefinition",
+      "operationTypes": [
+        {
+          "kind": "OperationTypeDefinition",
+          "operation": "query",
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "loc": {
+                "end": 134,
+                "start": 129,
+              },
+              "value": "Query",
+            },
+          },
+        },
+        {
+          "kind": "OperationTypeDefinition",
+          "operation": "mutation",
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "loc": {
+                "end": 226,
+                "start": 218,
+              },
+              "value": "Mutation",
+            },
+          },
+        },
+      ],
+    },
+  ],
+  "kind": "Document",
+}
+`;
+
+exports[`loadFile when the file path is valid should return a valid schema 1`] = `
 {
   "definitions": [
     {

--- a/__tests__/get-import-paths.test.ts
+++ b/__tests__/get-import-paths.test.ts
@@ -1,0 +1,35 @@
+import { getImportPaths } from '../src/get-import-paths'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('getImportPaths', () => {
+  describe('when file has file import annotation', () => {
+    it('should return the path of the files that were inserted by the annotation', () => {
+      const expectedResult = ['./user/user.test.graphql', './location/location.test.graphql']
+
+      const fileContent = readFileSync(
+        join(process.cwd(), './__tests__/mocks/with-import/root.test.graphql'),
+        'utf8'
+      )
+
+      const pathFiles = getImportPaths(fileContent)
+
+      expect(pathFiles.length).toBe(2)
+      expect(pathFiles).toEqual(expectedResult)
+    })
+  })
+
+  describe('when file has no file import annotation', () => {
+    it('should return an empty list', () => {
+      const fileContent = readFileSync(
+        join(process.cwd(), './__tests__/mocks/with-import/root-without-import.test.graphql'),
+        'utf8'
+      )
+
+      const pathFiles = getImportPaths(fileContent)
+
+      expect(pathFiles.length).toBe(0)
+      expect(pathFiles).toEqual([])
+    })
+  })
+})

--- a/__tests__/loadFile.test.ts
+++ b/__tests__/loadFile.test.ts
@@ -1,15 +1,23 @@
 import { loadFile } from '../src'
 
 describe('loadFile', () => {
-  describe('success', () => {
-    it('should valid schema', () => {
+  describe('when the file path is valid', () => {
+    it('should return a valid schema', () => {
       const schema = loadFile('./__tests__/mocks/file/user.test.graphql')
 
       expect(schema).toMatchSnapshot()
     })
   })
 
-  describe('failure', () => {
+  describe('when file path is valid and has file import annotation', () => {
+    it('should valid schema', () => {
+      const schema = loadFile('./__tests__/mocks/with-import/root.test.graphql')
+
+      expect(schema).toMatchSnapshot()
+    })
+  })
+
+  describe('when file path does not exist', () => {
     it('should an error when not finding the file', () => {
       expect(() => loadFile('./__tests__/mocks/file/error.graphql')).toThrowError()
     })

--- a/__tests__/mocks/with-import/location/location.test.graphql
+++ b/__tests__/mocks/with-import/location/location.test.graphql
@@ -1,0 +1,12 @@
+type Location {
+  id: ID!
+  name: String!
+  description: String!
+  photo: String!
+}
+
+input locationInput {
+  name: String!
+  description: String!
+  photo: String!
+}

--- a/__tests__/mocks/with-import/root-without-import.test.graphql
+++ b/__tests__/mocks/with-import/root-without-import.test.graphql
@@ -1,0 +1,29 @@
+type Query {
+  user(id: ID!): User!
+  users: [User!]!
+  locations: [Location!]!
+}
+
+type Mutation {
+  addLocation(locationInput: locationInput!): Location!
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+
+type Location {
+  id: ID!
+  name: String!
+  description: String!
+  photo: String!
+}
+
+input locationInput {
+  name: String!
+  description: String!
+  photo: String!
+}
+
+

--- a/__tests__/mocks/with-import/root.test.graphql
+++ b/__tests__/mocks/with-import/root.test.graphql
@@ -1,0 +1,15 @@
+#import './user/user.test.graphql'
+#import "./location/location.test.graphql"
+
+#random comment
+#imports 'aaaaa/ssss'
+
+type Query {
+  user(id: ID!): User!
+  users: [User!]!
+  locations: [Location!]!
+}
+
+type Mutation {
+  addLocation(locationInput: locationInput!): Location!
+}

--- a/__tests__/mocks/with-import/user/user.test.graphql
+++ b/__tests__/mocks/with-import/user/user.test.graphql
@@ -1,0 +1,4 @@
+type User {
+  id: ID!
+  name: String!
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-import-files",
-  "version": "1.1.18",
+  "version": "1.2.18",
   "description": "Light and easy package that will load .graphql files and use them with syntax highlighting.",
   "repository": "git@github.com:tiago154/graphql-import-files.git",
   "main": "dist/index.js",
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "jest",
     "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
-    "build": "tsc"
+    "build": "tsc",
+    "coverage": "npx http-server coverage/lcov-report"
   },
   "author": "Tiago Santos Da Silva",
   "license": "MIT",

--- a/src/get-import-paths.ts
+++ b/src/get-import-paths.ts
@@ -1,0 +1,10 @@
+/**
+ * Checks for external files imported by the #import annotation in a file and returns the paths if any
+ * @param {string} fileContent
+ * @returns {string[] | []} The list of file paths with #import notation
+ */
+export const getImportPaths = (fileContent: string): string[] | [] =>
+  fileContent
+    .split(/\r?\n/)
+    .filter((line) => line.match(/^#import\s/g))
+    .map(line => line.match(/'.*'|".*"/g)!.toString().replace(/'|"/g, ''))

--- a/src/loadFile.ts
+++ b/src/loadFile.ts
@@ -1,13 +1,27 @@
 import { readFileSync } from 'fs'
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { mergeTypeDefs } from '@graphql-tools/merge'
 import { DocumentNode } from 'graphql'
+import { getImportPaths } from './get-import-paths'
 
 /**
- * Place the path of the file to be imported, considering the root of the project.
+ * Put the path of the file to be imported, considering the root of the project i.e. the directory from where you invoked the node command
  * @example ./schemas/file.graphql
  * @param {string} pathFile
  * @return {DocumentNode} DocumentNode
  */
-export const loadFile = (pathFile: string) : DocumentNode =>
-  mergeTypeDefs(readFileSync(join(process.cwd(), pathFile), 'utf8'))
+export const loadFile = (pathFile: string): DocumentNode => {
+  const fileContent = readFileSync(join(process.cwd(), pathFile), 'utf8')
+
+  const externalFilePaths = getImportPaths(fileContent)
+
+  const contentExternalFiles = externalFilePaths.map(externalFilePath => readFileSync(
+    join(process.cwd(), dirname(pathFile), externalFilePath),
+    'utf8'
+  ))
+
+  return mergeTypeDefs([
+    fileContent,
+    ...contentExternalFiles
+  ])
+}


### PR DESCRIPTION
As per this suggestion here #16 , support for the `#import` annotation has been added, which allows the `loadFile` function to read external files and link to the initial file.